### PR TITLE
Upgrade bcprov-jdk18on to 1.78

### DIFF
--- a/webpush/pom.xml
+++ b/webpush/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.76</version>
+      <version>1.78</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
we have one project depends on 
```
-  dev.blanke.webpush.jwt:webpush-jwt-jose4j:jar:6.1.2:compile
|     +- dev.blanke.webpush:webpush:jar:6.1.1:compile
|     |  \- org.bouncycastle:bcprov-jdk18on:jar:1.76:compile
```

the recent security scanning reports the following CVEs: CVE-2024-29857, CVE-2024-30172, CVE-2024-30171

in order to solve this issue, we need to update the version to its latest