### PR TITLE
Fix to avoid NPE

### DIFF
--- a/webpush/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/webpush/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -38,7 +38,9 @@ public interface PushService extends AutoCloseable {
         return (vapidKeyPair.getPublic() != null) && (vapidKeyPair.getPrivate() != null);
     }
 
-    String getVapidSubject();
+    default String getVapidSubject() {
+        return "";
+    };
 
     default HttpResponse<Void> send(final Notification notification) throws Exception {
         return send(notification, DEFAULT_ENCODING);


### PR DESCRIPTION
Setting empty string as default for vapidSubject in order to avoid NPE during map initialization in AbstractPushService line 129.